### PR TITLE
fix: remove uv dependency from docs site build

### DIFF
--- a/scripts/build_docs_site.sh
+++ b/scripts/build_docs_site.sh
@@ -12,4 +12,4 @@ if ! command -v quarto >/dev/null 2>&1; then
 fi
 
 quarto render "$ROOT_DIR/docs"
-uv run python "$ROOT_DIR/scripts/check_docs_site.py" --site-root "$OUT_DIR"
+python3 "$ROOT_DIR/scripts/check_docs_site.py" --site-root "$OUT_DIR"

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -31,6 +31,8 @@ class DocsSiteContractTests(unittest.TestCase):
         self.assertIn("quarto render", script)
         self.assertIn("target/docs-site", script)
         self.assertIn("check_docs_site.py", script)
+        self.assertIn("python3", script)
+        self.assertNotIn("uv run python", script)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove the docs-site build script's unnecessary uv dependency
- run the docs-site checker with python3 so GitHub Pages builds work on stock runners
- add a regression test that keeps uv out of the docs build path

## Root Cause
- the docs workflow installs Quarto but not uv
- scripts/build_docs_site.sh called `uv run python` for a stdlib-only checker
- the push-to-main docs deployment therefore failed with `uv: command not found`

## Test Plan
- uv run python -m unittest tests.test_docs_site tests.test_scripts tests.test_repo_config -v